### PR TITLE
Fix retrosheet ids to allow for short last names

### DIFF
--- a/bc/models/intermediate/bio/people.sql
+++ b/bc/models/intermediate/bio/people.sql
@@ -49,7 +49,7 @@ joined AS (
 
 final AS (
     SELECT
-        CASE WHEN person_id SIMILAR TO '[a-z]{5}[01][0-9]{2}' THEN person_id ELSE NULL END AS player_id,
+        CASE WHEN person_id SIMILAR TO '[-a-z]{5}[01][0-9]{2}' THEN person_id ELSE NULL END AS player_id,
         *
     FROM joined
 )


### PR DESCRIPTION
Currently, the pattern `[a-z]{5}[01][0-9]{2}` is used to check whether a `person_id` is also a valid `player_id`. However this pattern fails for players who have last names shorter than 4 letters, such as Gavin Lux (`lux-g001`) or Chin-lung Hu (`hu--c001`). I've updated the pattern to `[-a-z]{5}[01][0-9]{2}` to allow for this type of player. 

